### PR TITLE
Fix: remove `&` from set names

### DIFF
--- a/enka_to_go/zo/converter.py
+++ b/enka_to_go/zo/converter.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 class EnkaToZOConverter:
     @classmethod
     def _format_key(cls, key: str) -> str:
-        return key.replace("'", "").replace('"', "").replace("-", " ").title().replace(" ", "")
+        return key.replace("'", "").replace('"', "").replace("-", " ").replace("&", "").title().replace(" ", "")
 
     @classmethod
     def convert(cls, agents: list[Agent]) -> dict[str, Any]:


### PR DESCRIPTION
@seriaati 
This pull request makes a small adjustment to the key formatting logic in the `EnkaToZOConverter` class. The change ensures that ampersands (`&`) are also removed from keys during formatting, in addition to the existing character replacements. 

([enka_to_go/zo/converter.pyL14-R14](diffhunk://#diff-6646fdff8db0289ac3c1b60da1ee71d1ed706606e51f16067aff52b53a3319c0L14-R14))

I noticed that some of my disks weren't recognized correctly. ZO defaults to the "Astral Voice" set if it doesn't recognize the set name and the app currently exports disks from the "Branch & Blade Song" set as `Branch&BladeSong`:
[export.json](https://github.com/user-attachments/files/24548958/export.json)
ZO doesn't recognize these and changes them to "AstralVoice" (see my disks on `YeShunguang` - the two `AstralVoice` disks should be `BranchBladeSong`. Here is my database for comparison (search for `BranchBladeSong`):
[Database_1_2026-01-11_07-29-33.json](https://github.com/user-attachments/files/24548957/Database_1_2026-01-11_07-29-33.json).

Export after the fix:
[export_fixed.json](https://github.com/user-attachments/files/24548983/export_fixed.json)

I did this in my original PR in the loader here: https://github.com/seriaati/enka-to-go/blob/fa76e9d37d705f2ab577cdc4177189360376224b/enka_to_go/zo/loader.py#L17 because enka-py didn't have the `set_name` but I think this got lost during the refactor.

The replace is the same for Genshin btw, though I don't think we have a set name with any special characters there yet, so it may not be relevant but could be worth creating a helper function for this if you want to use it in both places.